### PR TITLE
Enable latest MacOS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # TODO: re-enable test on MacOS once we have a way to install TeXlive
-          #- macos-latest
+          - macos-14
           - windows-latest
         ruby:
          - '3.1'


### PR DESCRIPTION
Thank to the hint by @muzimuzhi at https://github.com/zauguin/install-texlive/pull/12#issuecomment-1989189729, I got the action to work. One needs to use a NEWER macos than `macos-latest`, which is `macos-14`.

Here the result:

![image](https://github.com/reitzig/ltx2any/assets/1366654/d02b7493-7f20-49b0-afd6-2b7629f8bdd2)

I could not let the jobs rerun, but I assert if the failed jobs are rerun, the succeed.